### PR TITLE
Fix failing PhotosetsInterfaceTest

### DIFF
--- a/flickrj-android/src/test/java/com/googlecode/flickrjandroid/photosets/PhotosetsInterfaceTest.java
+++ b/flickrj-android/src/test/java/com/googlecode/flickrjandroid/photosets/PhotosetsInterfaceTest.java
@@ -43,7 +43,7 @@ public class PhotosetsInterfaceTest extends AbstractFlickrTest {
 		Photoset photoset = f.getPhotosetsInterface().getInfo(CHARLES_PHOTO_SET_ID);
 		assertNotNull(photoset);
 		assertEquals(CHARLES_PHOTO_SET_ID, photoset.getId());
-		assertTrue( photoset.getPhotoCount() > 60 );
+		assertTrue( photoset.getPhotoCount() > 50 );
 	}
 	
 	@Test


### PR DESCRIPTION
Charles must have been reorganising his sets :)

The test set only contains 58 photos -- update
com.googlecode.flickrjandroid.photosets.PhotosetsInterfaceTest to
account for this.
