### PR TITLE
Use https by default for all API requests

### DIFF
--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/Flickr.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/Flickr.java
@@ -58,8 +58,6 @@ public class Flickr {
     /**
      * The default endpoint host.
      */
-    public static final String DEFAULT_HOST = "www.flickr.com";
-    
     public static final String DEFAULT_API_HOST = "api.flickr.com";
 
     /**
@@ -220,7 +218,7 @@ public class Flickr {
     public Flickr(String apiKey) {
         setApiKey(apiKey);
         try {
-            setTransport(new REST(DEFAULT_HOST));
+            setTransport(new REST(DEFAULT_API_HOST));
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/REST.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/REST.java
@@ -58,7 +58,7 @@ public class REST extends Transport {
      */
     public REST() throws ParserConfigurationException {
         setTransportType(REST);
-        setHost(Flickr.DEFAULT_HOST);
+        setHost(Flickr.DEFAULT_API_HOST);
         setPath(PATH);
         setResponseClass(RESTResponse.class);
         DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/Transport.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/Transport.java
@@ -30,7 +30,7 @@ public abstract class Transport {
     protected Class<?> responseClass;
     private String path;
     private String host;
-    private int port = 80;
+    private int port = 443;
 
     public String getHost() {
         return host;

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/oauth/OAuthInterface.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/oauth/OAuthInterface.java
@@ -45,10 +45,10 @@ public class OAuthInterface {
     public static final String PATH_OAUTH_REQUEST_TOKEN = "/services/oauth/request_token";
     public static final String PATH_OAUTH_ACCESS_TOKEN = "/services/oauth/access_token";
     public static final String PATH_REST = "/services/rest";
-    public static final String URL_REQUEST_TOKEN = "http://" + Flickr.DEFAULT_HOST + PATH_OAUTH_REQUEST_TOKEN;
-    public static final String URL_ACCESS_TOKEN = "http://" + Flickr.DEFAULT_HOST + PATH_OAUTH_ACCESS_TOKEN;
+    public static final String URL_REQUEST_TOKEN = "https://" + Flickr.DEFAULT_API_HOST + PATH_OAUTH_REQUEST_TOKEN;
+    public static final String URL_ACCESS_TOKEN = "https://" + Flickr.DEFAULT_API_HOST + PATH_OAUTH_ACCESS_TOKEN;
 
-    public static final String URL_REST = "http://" + Flickr.DEFAULT_HOST + PATH_REST;
+    public static final String URL_REST = "https://" + Flickr.DEFAULT_API_HOST + PATH_REST;
 
     public static final String PARAM_OAUTH_CONSUMER_KEY = "oauth_consumer_key";
     public static final String PARAM_OAUTH_TOKEN = "oauth_token";
@@ -202,7 +202,7 @@ public class OAuthInterface {
         int port = oauthTransport.getPort();
         String path = "/services/oauth/authorize";
 
-        return UrlUtilities.buildUrl(Flickr.DEFAULT_HOST, port, path, parameters);
+        return UrlUtilities.buildUrl(Flickr.DEFAULT_API_HOST, port, path, parameters);
     }
 
 }

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photos/Photo.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photos/Photo.java
@@ -703,7 +703,7 @@ public class Photo implements Serializable {
 
     private StringBuffer _getBaseImageUrl() {
         StringBuffer buffer = new StringBuffer();
-        buffer.append("http://farm");
+        buffer.append("https://farm");
         buffer.append(getFarm());
         buffer.append(".static.flickr.com/");
         buffer.append(getServer());

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photos/PhotoUtils.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photos/PhotoUtils.java
@@ -160,7 +160,7 @@ public final class PhotoUtils {
                 photo.setOwner(owner);
             }
             
-            photo.setUrl("http://flickr.com/photos/" + owner.getId() + "/"
+            photo.setUrl("https://flickr.com/photos/" + owner.getId() + "/"
                     + photo.getId());
         }
         

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photosets/Photoset.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photosets/Photoset.java
@@ -45,7 +45,7 @@ public class Photoset implements Serializable {
     public String getUrl() {
         if(url == null) {
             StringBuffer sb = new StringBuffer();
-            sb.append("http://www.flickr.com/photos/");
+            sb.append("https://www.flickr.com/photos/");
             sb.append(getOwner().getId());
             sb.append("/sets/");
             sb.append(getId());

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/uploader/Uploader.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/uploader/Uploader.java
@@ -43,9 +43,9 @@ import com.googlecode.flickrjandroid.util.StringUtilities;
  */
 public class Uploader {
     public static final String UPLOAD_PATH = "/services/upload/";
-    public static final String URL_UPLOAD = "http://" + Flickr.DEFAULT_API_HOST + UPLOAD_PATH;
+    public static final String URL_UPLOAD = "https://" + Flickr.DEFAULT_API_HOST + UPLOAD_PATH;
     public static final String REPLACE_PATH = "/services/replace/";
-    public static final String URL_REPLACE = "http://" + Flickr.DEFAULT_API_HOST + REPLACE_PATH;
+    public static final String URL_REPLACE = "https://" + Flickr.DEFAULT_API_HOST + REPLACE_PATH;
     private String apiKey;
     private String sharedSecret;
     private Transport transport;

--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/util/UrlUtilities.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/util/UrlUtilities.java
@@ -37,7 +37,7 @@ public class UrlUtilities {
         // AuthUtilities.addAuthToken(parameters);
 
         StringBuffer buffer = new StringBuffer();
-        buffer.append("http://");
+        buffer.append("https://");
         buffer.append(host);
         if (port > 0 & port != 80) {
             buffer.append(":");
@@ -76,7 +76,7 @@ public class UrlUtilities {
 
     public static URL buildPostUrl(String host, int port, String path) throws MalformedURLException {
         StringBuffer buffer = new StringBuffer();
-        buffer.append("http://");
+        buffer.append("https://");
         buffer.append(host);
         if (port > 0) {
             buffer.append(":");
@@ -129,9 +129,9 @@ public class UrlUtilities {
         /**
          * The default-URL, if the iconServer equals 0.
          */
-        String iconUrl = "http://www.flickr.com/images/buddyicon.jpg";
+        String iconUrl = "https://www.flickr.com/images/buddyicon.jpg";
         if (iconServer > 0) {
-            iconUrl = "http://farm"
+            iconUrl = "https://farm"
             + iconFarm + ".static.flickr.com/"
             + iconServer + "/buddyicons/"
             + id + ".jpg";


### PR DESCRIPTION
Flickr API Going SSL-Only on June 27th, 2014

See:
http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/

Important details:
- Non SSL access is being removed by Flickr, all new requests must go
  to the https://api.flickr.com endpoint
- All requests to http://www.flickr.com will be redirected to the https
  version.
