### PR TITLE
Improved handling of JSON data types

### DIFF
--- a/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photos/PhotosInterface.java
+++ b/flickrj-android/src/main/java/com/googlecode/flickrjandroid/photos/PhotosInterface.java
@@ -441,7 +441,7 @@ public class PhotosInterface {
             JSONObject exifElement = exifElements.getJSONObject(i);
             Exif exif = new Exif();
             exif.setTagspace(exifElement.getString("tagspace"));
-            exif.setTagspaceId(exifElement.getString("tagspaceid"));
+            exif.setTagspaceId(Integer.toString(exifElement.getInt("tagspaceid")));
             exif.setTag(exifElement.getString("tag"));
             exif.setLabel(exifElement.getString("label"));
             exif.setRaw(JSONUtils.getChildValue(exifElement, "raw"));


### PR DESCRIPTION
JSON response to flickr.photos.getExif has subtly changed. tagspaceid is not an Integer

Fixes #26