### PR TITLE
Added description about use on Android WebView in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ It resolves the following issues that currently exist in FlickrJ:
 6. Added some fuctions missings in the original FlickrJ, such as GalleryInterface and CollectionInterface.  
 7. Use https by default for all API requests(thanks to Paul Bourke): http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/. Please use version 2.1.0+
 
+In case of login with Android WebView, following configuration is required.
+```
+webView.getSettings().setJavaScriptEnabled(true);
+webView.getSettings().setDomStorageEnabled(true);
+```
+
 This project is now available on both [Google Code](http://code.google.com/p/flickrj-android/) and [GitHub](https://github.com/yuyang226/FlickrjApi4Android).
 
 -Toby Yu(yuyang226@gmail.com)


### PR DESCRIPTION
If you choose "Mobile Application" as a app type on Flickr developer console, redirect URL will be "https://www.flickr.com/***" so WebView may be required. Unless localStorage is enabled, login fails. But it is disabled by default.